### PR TITLE
Add context to Synchronizer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,10 @@ jobs:
     name: Test
     runs-on: ubuntu-18.04
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Checkout
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Checkout


### PR DESCRIPTION
It will help to cancel all health check functions when the first error encountered.