### PR TITLE
Improve health checker safety

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/heartwilltell/hc
 
-go 1.24
-
-require golang.org/x/sync v0.13.0
+go 1.22

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=

--- a/hc.go
+++ b/hc.go
@@ -52,7 +52,7 @@ func (c *MultiChecker) Health(ctx context.Context) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	checkCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var firstErr firstError
@@ -63,7 +63,7 @@ func (c *MultiChecker) Health(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 
-			if err := runHealthCheck(ctx, check); err != nil {
+			if err := runHealthCheck(checkCtx, check); err != nil {
 				firstErr.set(err)
 				cancel()
 			}
@@ -141,13 +141,14 @@ type MultiServiceChecker struct {
 
 // NewMultiServiceChecker creates a new MultiServiceChecker with the given services.
 func NewMultiServiceChecker(report *ServiceReport) *MultiServiceChecker {
-	if report == nil {
-		report = NewServiceReport()
+	serviceReport := report
+	if serviceReport == nil {
+		serviceReport = NewServiceReport()
 	}
 
 	return &MultiServiceChecker{
 		services: make(map[string]HealthChecker),
-		report:   report,
+		report:   serviceReport,
 	}
 }
 
@@ -234,6 +235,7 @@ func NewNopChecker() NopChecker { return NopChecker{} }
 func (NopChecker) Health(context.Context) error { return nil }
 
 // Synchronizer holds synchronization mechanics.
+//
 // Deprecated: Use sync.WaitGroup or another coordination primitive instead.
 type Synchronizer struct {
 	wg     sync.WaitGroup
@@ -306,7 +308,7 @@ func isNilHealthChecker(checker HealthChecker) bool {
 
 	value := reflect.ValueOf(checker)
 	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return value.IsNil()
 	default:
 		return false

--- a/hc.go
+++ b/hc.go
@@ -3,11 +3,11 @@ package hc
 
 import (
 	"context"
+	"errors"
 	"maps"
+	"reflect"
 	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 )
 
 // Compilation time checks for interface implementation.
@@ -25,6 +25,9 @@ type HealthChecker interface {
 	Health(ctx context.Context) error
 }
 
+// ErrNilChecker is returned when a nil HealthChecker is registered.
+var ErrNilChecker = errors.New("hc: nil health checker")
+
 // NewMultiChecker takes several health checkers and performs
 // health checks for each of them concurrently.
 func NewMultiChecker(hcs ...HealthChecker) *MultiChecker {
@@ -35,23 +38,60 @@ func NewMultiChecker(hcs ...HealthChecker) *MultiChecker {
 
 // MultiChecker takes multiple health checker and performs
 // health checks for each of them concurrently.
-type MultiChecker struct{ hcs []HealthChecker }
+type MultiChecker struct {
+	mu  sync.RWMutex
+	hcs []HealthChecker
+}
 
 // Health takes the context and performs the health check.
 // Returns nil in case of success or an error in case
 // of a failure.
 func (c *MultiChecker) Health(ctx context.Context) error {
-	g, gctx := errgroup.WithContext(ctx)
-
-	for _, check := range c.hcs {
-		g.Go(func() error { return check.Health(gctx) })
+	hcs := c.checkers()
+	if len(hcs) == 0 {
+		return nil
 	}
 
-	return g.Wait()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstErr firstError
+	var wg sync.WaitGroup
+	for _, check := range hcs {
+		check := check
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			if err := runHealthCheck(ctx, check); err != nil {
+				firstErr.set(err)
+				cancel()
+			}
+		}()
+	}
+
+	wg.Wait()
+	return firstErr.err
 }
 
 // Add appends health HealthChecker to internal slice of HealthCheckers.
-func (c *MultiChecker) Add(hc HealthChecker) { c.hcs = append(c.hcs, hc) }
+func (c *MultiChecker) Add(hc HealthChecker) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.hcs = append(c.hcs, hc)
+}
+
+func (c *MultiChecker) checkers() []HealthChecker {
+	if c == nil {
+		return nil
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return append([]HealthChecker(nil), c.hcs...)
+}
 
 // ServiceStatus represents the status of a service health check.
 type ServiceStatus struct {
@@ -71,20 +111,40 @@ func NewServiceReport() *ServiceReport { return &ServiceReport{st: make(map[stri
 
 // GetStatuses returns a copy of all service statuses.
 func (r *ServiceReport) GetStatuses() map[string]ServiceStatus {
+	if r == nil {
+		return nil
+	}
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	return maps.Clone(r.st)
 }
 
+func (r *ServiceReport) setStatus(name string, status ServiceStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.st == nil {
+		r.st = make(map[string]ServiceStatus)
+	}
+
+	r.st[name] = status
+}
+
 // MultiServiceChecker implements the HealthChecker interface for checking multiple services.
 type MultiServiceChecker struct {
+	mu       sync.RWMutex
 	services map[string]HealthChecker
 	report   *ServiceReport
 }
 
 // NewMultiServiceChecker creates a new MultiServiceChecker with the given services.
 func NewMultiServiceChecker(report *ServiceReport) *MultiServiceChecker {
+	if report == nil {
+		report = NewServiceReport()
+	}
+
 	return &MultiServiceChecker{
 		services: make(map[string]HealthChecker),
 		report:   report,
@@ -93,6 +153,9 @@ func NewMultiServiceChecker(report *ServiceReport) *MultiServiceChecker {
 
 // Report returns a service report.
 func (c *MultiServiceChecker) Report() *ServiceReport {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.report == nil {
 		c.report = NewServiceReport()
 	}
@@ -102,37 +165,64 @@ func (c *MultiServiceChecker) Report() *ServiceReport {
 
 // AddService adds a service to be checked.
 func (c *MultiServiceChecker) AddService(name string, checker HealthChecker) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.services == nil {
+		c.services = make(map[string]HealthChecker)
+	}
+
 	c.services[name] = checker
 }
 
 // Health implements the HealthChecker interface.
 func (c *MultiServiceChecker) Health(ctx context.Context) error {
-	if len(c.services) == 0 {
+	services, report := c.snapshot()
+	if len(services) == 0 {
 		return nil
 	}
 
-	var g errgroup.Group
+	var firstErr firstError
+	var wg sync.WaitGroup
+	for name, checker := range services {
+		name, checker := name, checker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 
-	for name, checker := range c.services {
-		g.Go(func() error {
 			startTime := time.Now()
-			checkErr := checker.Health(ctx)
-			duration := time.Since(startTime)
+			checkErr := runHealthCheck(ctx, checker)
+			checkedAt := time.Now()
 
-			c.report.mu.Lock()
-			defer c.report.mu.Unlock()
-
-			c.report.st[name] = ServiceStatus{
+			report.setStatus(name, ServiceStatus{
 				Error:     checkErr,
-				Duration:  duration,
-				CheckedAt: time.Now(),
-			}
+				Duration:  checkedAt.Sub(startTime),
+				CheckedAt: checkedAt,
+			})
 
-			return checkErr
-		})
+			if checkErr != nil {
+				firstErr.set(checkErr)
+			}
+		}()
 	}
 
-	return g.Wait()
+	wg.Wait()
+	return firstErr.err
+}
+
+func (c *MultiServiceChecker) snapshot() (map[string]HealthChecker, *ServiceReport) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.report == nil {
+		c.report = NewServiceReport()
+	}
+	if len(c.services) == 0 {
+		return nil, c.report
+	}
+
+	services := maps.Clone(c.services)
+	return services, c.report
 }
 
 // NopChecker represents nop health checker.
@@ -144,7 +234,7 @@ func NewNopChecker() NopChecker { return NopChecker{} }
 func (NopChecker) Health(context.Context) error { return nil }
 
 // Synchronizer holds synchronization mechanics.
-// Deprecated: Use errgroup.Group instead.
+// Deprecated: Use sync.WaitGroup or another coordination primitive instead.
 type Synchronizer struct {
 	wg     sync.WaitGroup
 	so     sync.Once
@@ -154,7 +244,13 @@ type Synchronizer struct {
 
 // Error returns a string representation of underlying error.
 // Implements builtin error interface.
-func (s *Synchronizer) Error() string { return s.err.Error() }
+func (s *Synchronizer) Error() string {
+	if s == nil || s.err == nil {
+		return ""
+	}
+
+	return s.err.Error()
+}
 
 // SetError sets an error to the Synchronizer structure.
 // Uses sync.Once to set error only once.
@@ -174,4 +270,45 @@ func (s *Synchronizer) Wait() { s.wg.Wait() }
 
 // Cancel calls underlying cancel function to cancel context,
 // which passed to all health checks function.
-func (s *Synchronizer) Cancel() { s.cancel() }
+func (s *Synchronizer) Cancel() {
+	if s == nil || s.cancel == nil {
+		return
+	}
+
+	s.cancel()
+}
+
+type firstError struct {
+	once sync.Once
+	err  error
+}
+
+func (e *firstError) set(err error) {
+	if err == nil {
+		return
+	}
+
+	e.once.Do(func() { e.err = err })
+}
+
+func runHealthCheck(ctx context.Context, checker HealthChecker) error {
+	if isNilHealthChecker(checker) {
+		return ErrNilChecker
+	}
+
+	return checker.Health(ctx)
+}
+
+func isNilHealthChecker(checker HealthChecker) bool {
+	if checker == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(checker)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/hc_test.go
+++ b/hc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -107,6 +108,42 @@ func TestMultiChecker_Add(t *testing.T) {
 	if !reflect.DeepEqual(mc2.hcs[1], tc2) {
 		t.Errorf("Add after init [1]: expected = %v, got = %v", tc2, mc2.hcs[1])
 	}
+
+	mc3 := NewMultiChecker(tc1)
+	mc3.Add(tc2)
+
+	if len(mc3.hcs) != 2 {
+		t.Fatalf("Add: expected len = 2, got = %d", len(mc3.hcs))
+	}
+	if !reflect.DeepEqual(mc3.hcs[1], tc2) {
+		t.Errorf("Add: expected appended checker = %v, got = %v", tc2, mc3.hcs[1])
+	}
+}
+
+func TestMultiChecker_NilChecker(t *testing.T) {
+	checker := NewMultiChecker(nil)
+
+	if err := checker.Health(context.Background()); !errors.Is(err, ErrNilChecker) {
+		t.Fatalf("Health() error = %v, want %v", err, ErrNilChecker)
+	}
+}
+
+func TestMultiChecker_ConcurrentHealthAndAdd(t *testing.T) {
+	checker := NewMultiChecker(&testChecker{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = checker.Health(context.Background())
+		}()
+		go func() {
+			defer wg.Done()
+			checker.Add(&testChecker{})
+		}()
+	}
+	wg.Wait()
 }
 
 type testChecker struct {
@@ -165,7 +202,7 @@ func TestMultiServiceChecker_Health(t *testing.T) {
 		if status.CheckedAt.IsZero() {
 			t.Errorf("'ok_service' CheckedAt should not be zero")
 		}
-		
+
 		if status.Duration < 0 {
 			t.Errorf("'ok_service' Duration should be non-negative, got %v", status.Duration)
 		}
@@ -222,6 +259,53 @@ func TestMultiServiceChecker_Health(t *testing.T) {
 	} else if status.Error != context.Canceled {
 		t.Errorf("Expected 'cancel_service' error to be context.Canceled, got %v", status.Error)
 	}
+}
+
+func TestMultiServiceChecker_NilReportHealth(t *testing.T) {
+	checker := NewMultiServiceChecker(nil)
+	checker.AddService("ok_service", &testChecker{})
+
+	if err := checker.Health(context.Background()); err != nil {
+		t.Fatalf("Health() error = %v, want nil", err)
+	}
+
+	statuses := checker.Report().GetStatuses()
+	if _, ok := statuses["ok_service"]; !ok {
+		t.Fatal("Status for 'ok_service' not found")
+	}
+}
+
+func TestMultiServiceChecker_NilChecker(t *testing.T) {
+	checker := NewMultiServiceChecker(nil)
+	checker.AddService("nil_service", nil)
+
+	if err := checker.Health(context.Background()); !errors.Is(err, ErrNilChecker) {
+		t.Fatalf("Health() error = %v, want %v", err, ErrNilChecker)
+	}
+
+	status := checker.Report().GetStatuses()["nil_service"]
+	if !errors.Is(status.Error, ErrNilChecker) {
+		t.Fatalf("reported error = %v, want %v", status.Error, ErrNilChecker)
+	}
+}
+
+func TestMultiServiceChecker_ConcurrentHealthAndAddService(t *testing.T) {
+	checker := NewMultiServiceChecker(nil)
+	checker.AddService("initial", &testChecker{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = checker.Health(context.Background())
+		}()
+		go func() {
+			defer wg.Done()
+			checker.AddService("service", &testChecker{})
+		}()
+	}
+	wg.Wait()
 }
 
 func TestMultiServiceChecker_Report(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the external errgroup dependency and use standard-library synchronization
- make checker/service registration safe to snapshot during concurrent health checks
- initialize nil service reports before health checks and return ErrNilChecker for nil checkers instead of panicking
- add regression coverage for nil reports, nil checkers, actual Add behavior, and concurrent health/check registration
- fix golangci-lint findings reported by CI

## Tests
- go test ./...
- go test -race ./...
- golangci-lint v2.12.2 run --timeout=3m
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45f53146-b0f4-4581-a68a-31d85d718a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45f53146-b0f4-4581-a68a-31d85d718a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

