### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the `github.com/heartwilltell/hc` Go **library** for concurrent health checks. There is no server, database, binary, or UI to run — "running the app" means building and exercising the package via tests.
+
+### Toolchain
+- The module requires **Go 1.24** (`go.mod`). The base image's system Go may be older (1.22), so Go 1.24 is installed at `/usr/local/go` and symlinked to `/usr/local/bin/go` (which precedes `/usr/bin` on `PATH`). `go version` should report `go1.24.x`.
+- Lint uses **golangci-lint v2** (`.golangci.yml` has `version: "2"`); v1 will not parse the config. It is installed in `$(go env GOPATH)/bin` and symlinked to `/usr/local/bin/golangci-lint`.
+
+### Common commands (from repo root)
+- Build: `go build ./...`
+- Test (matches CI): `go test -race -cover ./...`
+- Lint: `golangci-lint run --timeout=3m`
+
+### Notes
+- `golangci-lint run` currently reports one pre-existing finding on `master` (`hc.go:147` gocritic `deprecatedComment`); it is unrelated to environment setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for the `hc` Go health-check library and documents non-obvious setup details for future Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the required Go 1.24 toolchain, golangci-lint v2, and standard build/test/lint commands.

## Environment setup performed (not code changes)
- Installed **Go 1.24.4** (`go.mod` requires Go 1.24; base image had 1.22), symlinked to `/usr/local/bin/go`.
- Installed **golangci-lint v2** (config is `version: "2"`), symlinked to `/usr/local/bin/golangci-lint`.
- Update script set to `go mod download`.

## Verification
- ✅ `go build -v ./...`
- ✅ `go test -race -cover ./...` — `ok ... coverage: 78.0% of statements`
- ⚠️ `golangci-lint run --timeout=3m` — runs successfully; reports 1 pre-existing finding (`hc.go:147` gocritic `deprecatedComment`), unrelated to setup.
- ✅ Ran a standalone demo program using the library's `MultiServiceChecker`/`MultiChecker` to confirm core functionality end-to-end.

[hc_demo_output.log](https://cursor.com/agents/bc-d8665ac2-f36c-434b-99e8-d50ad5f59087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhc_demo_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8665ac2-f36c-434b-99e8-d50ad5f59087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8665ac2-f36c-434b-99e8-d50ad5f59087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

